### PR TITLE
Remove extra padding-right from search inputs, Fixes #828

### DIFF
--- a/style.css
+++ b/style.css
@@ -231,7 +231,7 @@ input[type="search"] {
 
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
-	-webkit-appearance: none;
+	display: none;
 }
 
 fieldset {


### PR DESCRIPTION
I've replaced `-webkit-appearance: none;` to `display: none;`, which fixes the problem, I hope this helps.